### PR TITLE
Feat: 게시글 제목 표기에 XSS 방지 처리 

### DIFF
--- a/src/main/webapp/WEB-INF/views/editPost.jsp
+++ b/src/main/webapp/WEB-INF/views/editPost.jsp
@@ -68,7 +68,7 @@
     <form action="/posts/${post.id}/edit" method="post">
         <div class="form-group">
             <label for="title">제목</label>
-            <input type="text" id="title" name="title" value="${post.title}" required>
+            <input type="text" id="title" name="title" value="<c:out value='${post.title}' />" required>
         </div>
 
         <div class="form-group">

--- a/src/main/webapp/WEB-INF/views/home.jsp
+++ b/src/main/webapp/WEB-INF/views/home.jsp
@@ -52,7 +52,7 @@
         <tr>
             <td>${post.id}</td>
             <td>
-                <a href="/posts/${post.id}" class="btn btn-view">${post.title}</a>
+                <a href="/posts/${post.id}" class="btn btn-view"><c:out value="${post.title}"/></a>
             </td>
             <td>
                 <a href="/posts/${post.id}/edit" class="btn btn-edit">수정</a>

--- a/src/main/webapp/WEB-INF/views/posts.jsp
+++ b/src/main/webapp/WEB-INF/views/posts.jsp
@@ -73,7 +73,7 @@
 <body>
 <div class="post-container">
     <div class="post-header">
-        <div class="post-title">${post.title}</div>
+        <div class="post-title"><c:out value="${post.title}"/></div>
         <div class="post-info">게시글 번호: ${post.id}</div>
     </div>
 


### PR DESCRIPTION
## 개요

- 게시글 제목 표기에 Escape 처리

## 참고 사항
- `JSP`는 `Thymeleaf`의 `th:text="${data}`와 다르게 기본적으로 렌더링 시 이스케이프 처리를 하지 않는다.
- 따라서 `data`에 `<script>alert('hi')</script>`를 넣어준다면, 페이지 조회 시 `hi`라는 알럿이 뜬다. 
- 이를 방지하기 위해서는 `<c:out>`, `${fn:escapeXml()}` 2가지 방법이 있다.
    - `<c:out>`은 태그이고, null일 경우 빈문자열을 출력한다.
    - `${fn:escapeXml()}`은 `EL(Expression Language)` 함수라서 다른 EL 내에서도 사용 가능하지만, null이면 null을 반환한다.
    - 단순 출력만 하면 되며, null처리까지 해주는 `<c:out>`으로 채택했다.
- 또한 DB에 저장할 때가 아닌 조회할 때 이스케이프 처리를 해준 이유는, DB에는 원본의 내용을 저장하고 클라이언트 환경에 따라 맞춰 렌더링하기 위하여 조회 부분에서 이스케이프 처리하기로 결정했다. 